### PR TITLE
Remove unused CSS for editor toolbar which has been unshipped

### DIFF
--- a/mesop/web/src/app/styles.scss
+++ b/mesop/web/src/app/styles.scss
@@ -182,14 +182,10 @@ body {
   @include mat.all-component-themes($light-theme);
   @include mat.color-variants-backwards-compatibility($light-theme);
   @include mat.system-level-colors($light-theme);
-
-  --mesop-editor-toolbar-background-rgb: 240, 237, 241;
 }
 
 body.dark-theme {
   @include mat.system-level-colors($dark-theme);
-
-  --mesop-editor-toolbar-background-rgb: 31, 31, 35;
 }
 
 $density-scales: (-1, -2, -3, -4);
@@ -213,8 +209,6 @@ body {
   // Use system font.
   font-family: var(--default-font-family);
   -webkit-font-smoothing: antialiased;
-
-  --mat-dialog-container-max-width: calc(90vw);
 }
 
 * {
@@ -404,12 +398,6 @@ mesop-markdown {
     border-collapse: collapse;
     padding: 10px;
   }
-}
-
-// Styles needed for the editor toolbar.
-
-.floating-editor-toolbar-autocomplete {
-  --mat-option-label-text-size: 0.9rem;
 }
 
 /*


### PR DESCRIPTION
This also avoids an internal API migration