### PR TITLE
fix(demo): capitalize input in text-to-text example

### DIFF
--- a/demo/text_to_text.py
+++ b/demo/text_to_text.py
@@ -22,4 +22,4 @@ def app():
 
 
 def upper_case_stream(s: str):
-  return "Echo: " + s
+  return "Echo: " + s.capitalize()


### PR DESCRIPTION
The demo for text_to_text is supposed to capitalize the input. It's actually correct in the readme but was wrong in the code.