### PR TITLE
Add coordinate values for click events + add right click event + add context menu example

### DIFF
--- a/demo/context_menu.py
+++ b/demo/context_menu.py
@@ -1,0 +1,136 @@
+"""Simple context menu example"""
+
+from pydantic import BaseModel
+
+import mesop as me
+
+
+class MenuItem(BaseModel):
+  label: str
+
+
+class Menu(BaseModel):
+  items: list[MenuItem]
+
+
+CONTEXT_MENU = Menu(
+  items=[
+    MenuItem(label="Item 1"),
+    MenuItem(label="Item 2"),
+    MenuItem(label="Item 3"),
+  ]
+)
+
+
+def on_load(e: me.LoadEvent):
+  me.set_theme_mode("system")
+
+
+@me.stateclass
+class State:
+  menu_active: bool = False
+  menu_pos_x: int = 0
+  menu_pos_y: int = 0
+  selected_menu_item: str
+
+
+@me.page(
+  path="/context_menu",
+  security_policy=me.SecurityPolicy(
+    allowed_iframe_parents=[
+      "https://mesop-dev.github.io",
+    ]
+  ),
+  stylesheets=["/static/context_menu.css"],
+  on_load=on_load,
+)
+def app():
+  state = me.state(State)
+
+  context_menu(CONTEXT_MENU)
+
+  with me.box(
+    style=me.Style(margin=me.Margin.all(15), width="100%", height="100%"),
+    on_right_click=on_right_click,
+  ):
+    me.text("Selected menu item: " + state.selected_menu_item)
+    me.text("[Right click anywhere show a context menu]")
+
+
+@me.component
+def context_menu(menu: Menu):
+  """Really simply context menu component."""
+  state = me.state(State)
+  with me.box(
+    on_click=on_click_outside_menu,
+    style=me.Style(
+      background="rgba(0, 0, 0, 0)",
+      # Use display block/none so that the event handler does not get removed.
+      # If we use a conditional, this event handler will not be found when it bubbles up
+      # on menu item click.
+      display="block" if state.menu_active else "none",
+      height="100%",
+      overflow_x="auto",
+      overflow_y="auto",
+      position="fixed",
+      width="100%",
+      z_index=1000,
+    ),
+  ):
+    with me.box(
+      style=me.Style(
+        position="absolute",
+        top=state.menu_pos_y,
+        left=state.menu_pos_x,
+      )
+    ):
+      with me.box(
+        style=me.Style(
+          background=me.theme_var("surface-container-highest"),
+          box_shadow="0 3px 1px -2px #0003, 0 2px 2px #00000024, 0 1px 5px #0000001f",
+          padding=me.Padding.symmetric(vertical=10),
+          min_width=125,
+          border_radius=10,
+        )
+      ):
+        for item in menu.items:
+          with me.box(
+            key=item.label,
+            classes="menu-item",
+            style=me.Style(
+              cursor="pointer",
+              padding=me.Padding.symmetric(vertical=10, horizontal=15),
+              font_weight="medium",
+            ),
+            on_click=on_click_menu_item,
+          ):
+            me.text(item.label)
+
+
+def on_click_menu_item(e: me.ClickEvent):
+  """Handles click events on context menu items"""
+  state = me.state(State)
+  state.selected_menu_item = e.key
+  state.menu_active = False
+  state.menu_pos_x = 0
+  state.menu_pos_y = 0
+
+
+def on_click_outside_menu(e: me.ClickEvent):
+  """Handles clicking outside the context menu when it is open (i.e. closes the context menu)"""
+  # Ensure the click is outside the context menu
+  if not e.is_target:
+    return
+  state = me.state(State)
+  state.selected_menu_item = ""
+  state.menu_active = False
+  state.menu_pos_x = 0
+  state.menu_pos_y = 0
+
+
+def on_right_click(e: me.RightClickEvent):
+  """Handle right click event by opening custom context menu"""
+  state = me.state(State)
+  state.menu_active = True
+  state.menu_pos_x = int(e.client_x)
+  state.menu_pos_y = int(e.client_y)

--- a/demo/main.py
+++ b/demo/main.py
@@ -33,6 +33,7 @@ import chat as chat
 import chat_inputs as chat_inputs
 import checkbox as checkbox
 import code_demo as code_demo  # cannot call it code due to python library naming conflict
+import context_menu as context_menu
 import date_picker as date_picker
 import date_range_picker as date_range_picker
 import density as density
@@ -109,6 +110,7 @@ FIRST_SECTIONS = [
   Section(
     name="Patterns",
     examples=[
+      Example(name="context_menu"),
       Example(name="dialog"),
       Example(name="grid_table"),
       Example(name="headers"),

--- a/demo/static/context_menu.css
+++ b/demo/static/context_menu.css
@@ -1,0 +1,3 @@
+.menu-item {
+  filter: brightness(0.8);
+}

--- a/mesop/__init__.py
+++ b/mesop/__init__.py
@@ -221,6 +221,9 @@ from mesop.events import (
 from mesop.events import (
   LoadEvent as LoadEvent,
 )
+from mesop.events import (
+  RightClickEvent as RightClickEvent,
+)
 from mesop.events import WebEvent as WebEvent
 from mesop.exceptions import (
   MesopDeveloperException as MesopDeveloperException,

--- a/mesop/component_helpers/helper.py
+++ b/mesop/component_helpers/helper.py
@@ -24,7 +24,13 @@ from google.protobuf.message import Message
 
 import mesop.protos.ui_pb2 as pb
 from mesop.component_helpers.style import Style, to_style_proto
-from mesop.events import ClickEvent, InputEvent, MesopEvent, WebEvent
+from mesop.events import (
+  ClickEvent,
+  InputEvent,
+  MesopEvent,
+  RightClickEvent,
+  WebEvent,
+)
 from mesop.exceptions import MesopDeveloperException
 from mesop.key import Key, key_from_proto
 from mesop.runtime import runtime
@@ -674,9 +680,28 @@ runtime().register_event_mapper(
   lambda userEvent, key: ClickEvent(
     key=key.key,
     is_target=userEvent.click.is_target,
+    client_x=userEvent.click.client_x,
+    client_y=userEvent.click.client_y,
+    page_x=userEvent.click.page_x,
+    page_y=userEvent.click.page_y,
+    offset_x=userEvent.click.offset_x,
+    offset_y=userEvent.click.offset_y,
   ),
 )
 
+runtime().register_event_mapper(
+  RightClickEvent,
+  lambda userEvent, key: RightClickEvent(
+    key=key.key,
+    is_target=userEvent.click.is_target,
+    client_x=userEvent.click.client_x,
+    client_y=userEvent.click.client_y,
+    page_x=userEvent.click.page_x,
+    page_y=userEvent.click.page_y,
+    offset_x=userEvent.click.offset_x,
+    offset_y=userEvent.click.offset_y,
+  ),
+)
 
 runtime().register_event_mapper(
   InputEvent,

--- a/mesop/components/box/box.proto
+++ b/mesop/components/box/box.proto
@@ -2,7 +2,9 @@ syntax = "proto2";
 
 package mesop.components.box;
 
+// Next ID: 5
 message BoxType {
     optional string on_click_handler_id = 2;
+    optional string on_right_click_handler_id = 4;
     repeated string classes = 3;
 }

--- a/mesop/components/box/box.py
+++ b/mesop/components/box/box.py
@@ -7,7 +7,7 @@ from mesop.component_helpers import (
   register_event_handler,
   register_native_component,
 )
-from mesop.events import ClickEvent
+from mesop.events import ClickEvent, RightClickEvent
 
 
 @register_native_component
@@ -15,6 +15,7 @@ def box(
   *,
   style: Style | None = None,
   on_click: Callable[[ClickEvent], Any] | None = None,
+  on_right_click: Callable[[RightClickEvent], Any] | None = None,
   classes: list[str] | str = "",
   key: str | None = None,
 ) -> Any:
@@ -24,6 +25,7 @@ def box(
     style: Style to apply to component. Follows [HTML Element inline style API](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/style).
     on_click: The callback function that is called when the box is clicked.
       It receives a ClickEvent as its only argument.
+    on_right_click: The callback function that is called when the box is right clicked. This will disable the default context menu behavior if set.
     classes: CSS classes.
     key: The component [key](../components/index.md#component-key).
 
@@ -36,6 +38,11 @@ def box(
     proto=box_pb.BoxType(
       on_click_handler_id=register_event_handler(on_click, event=ClickEvent)
       if on_click
+      else "",
+      on_right_click_handler_id=register_event_handler(
+        on_right_click, event=RightClickEvent
+      )
+      if on_right_click
       else "",
       classes=classes if isinstance(classes, list) else classes.split(" "),
     ),

--- a/mesop/components/box/e2e/__init__.py
+++ b/mesop/components/box/e2e/__init__.py
@@ -1,1 +1,2 @@
 from . import box_app as box_app
+from . import box_events_app as box_events_app

--- a/mesop/components/box/e2e/box_events_app.py
+++ b/mesop/components/box/e2e/box_events_app.py
@@ -1,0 +1,55 @@
+import mesop as me
+
+
+@me.stateclass
+class State:
+  is_click: bool = False
+  is_right_click: int = False
+  client_x: int = 0
+  client_y: int = 0
+  page_x: int = 0
+  page_y: int = 0
+  offset_x: int = 0
+  offset_y: int = 0
+
+
+@me.page(path="/components/box/e2e/box_events_app")
+def app():
+  state = me.state(State)
+  with me.box(
+    style=me.Style(width="100%", height="100%", margin=me.Margin.all(20)),
+    on_click=on_click,
+    on_right_click=on_right_click,
+  ):
+    me.text("Is Click: " + str(state.is_click))
+    me.text("Is Right Click: " + str(state.is_right_click))
+    me.text("Client X: " + str(state.client_x))
+    me.text("Client Y: " + str(state.client_y))
+    me.text("Page X: " + str(state.page_x))
+    me.text("Page Y: " + str(state.page_y))
+    me.text("Offset X: " + str(state.offset_x))
+    me.text("Offset Y: " + str(state.offset_y))
+
+
+def on_click(e: me.ClickEvent):
+  state = me.state(State)
+  state.is_click = True
+  state.is_right_click = False
+  state.client_x = e.client_x
+  state.client_y = e.client_y
+  state.page_x = e.page_x
+  state.page_y = e.page_y
+  state.offset_x = e.offset_x
+  state.offset_y = e.offset_y
+
+
+def on_right_click(e: me.ClickEvent):
+  state = me.state(State)
+  state.is_click = True
+  state.is_right_click = True
+  state.client_x = e.client_x
+  state.client_y = e.client_y
+  state.page_x = e.page_x
+  state.page_y = e.page_y
+  state.offset_x = e.offset_x
+  state.offset_y = e.offset_y

--- a/mesop/components/box/e2e/box_events_app.py
+++ b/mesop/components/box/e2e/box_events_app.py
@@ -35,21 +35,21 @@ def on_click(e: me.ClickEvent):
   state = me.state(State)
   state.is_click = True
   state.is_right_click = False
-  state.client_x = e.client_x
-  state.client_y = e.client_y
-  state.page_x = e.page_x
-  state.page_y = e.page_y
-  state.offset_x = e.offset_x
-  state.offset_y = e.offset_y
+  state.client_x = int(e.client_x)
+  state.client_y = int(e.client_y)
+  state.page_x = int(e.page_x)
+  state.page_y = int(e.page_y)
+  state.offset_x = int(e.offset_x)
+  state.offset_y = int(e.offset_y)
 
 
 def on_right_click(e: me.ClickEvent):
   state = me.state(State)
   state.is_click = True
   state.is_right_click = True
-  state.client_x = e.client_x
-  state.client_y = e.client_y
-  state.page_x = e.page_x
-  state.page_y = e.page_y
-  state.offset_x = e.offset_x
-  state.offset_y = e.offset_y
+  state.client_x = int(e.client_x)
+  state.client_y = int(e.client_y)
+  state.page_x = int(e.page_x)
+  state.page_y = int(e.page_y)
+  state.offset_x = int(e.offset_x)
+  state.offset_y = int(e.offset_y)

--- a/mesop/components/box/e2e/box_events_test.ts
+++ b/mesop/components/box/e2e/box_events_test.ts
@@ -1,0 +1,31 @@
+import {test, expect} from '@playwright/test';
+
+test('test click event', async ({page}) => {
+  await page.goto('/components/box/e2e/box_events_app');
+
+  await page.mouse.click(100, 100);
+
+  await expect(page.getByText('Is Click: True')).toBeVisible();
+  await expect(page.getByText('Is Right Click: False')).toBeVisible();
+  await expect(page.getByText('Client X: 100.0')).toBeVisible();
+  await expect(page.getByText('Client Y: 100.0')).toBeVisible();
+  await expect(page.getByText('Page X: 100.0')).toBeVisible();
+  await expect(page.getByText('Page Y: 100.0')).toBeVisible();
+  await expect(page.getByText('Offset X: 80.0')).toBeVisible();
+  await expect(page.getByText('Offset Y: 6.0')).toBeVisible();
+});
+
+test('test right click event', async ({page}) => {
+  await page.goto('/components/box/e2e/box_events_app');
+
+  await page.mouse.click(100, 100, {button: 'right'});
+
+  await expect(page.getByText('Is Click: True')).toBeVisible();
+  await expect(page.getByText('Is Right Click: True')).toBeVisible();
+  await expect(page.getByText('Client X: 100.0')).toBeVisible();
+  await expect(page.getByText('Client Y: 100.0')).toBeVisible();
+  await expect(page.getByText('Page X: 100.0')).toBeVisible();
+  await expect(page.getByText('Page Y: 100.0')).toBeVisible();
+  await expect(page.getByText('Offset X: 80.0')).toBeVisible();
+  await expect(page.getByText('Offset Y: 6.0')).toBeVisible();
+});

--- a/mesop/components/box/e2e/box_events_test.ts
+++ b/mesop/components/box/e2e/box_events_test.ts
@@ -7,12 +7,12 @@ test('test click event', async ({page}) => {
 
   await expect(page.getByText('Is Click: True')).toBeVisible();
   await expect(page.getByText('Is Right Click: False')).toBeVisible();
-  await expect(page.getByText('Client X: 100.0')).toBeVisible();
-  await expect(page.getByText('Client Y: 100.0')).toBeVisible();
-  await expect(page.getByText('Page X: 100.0')).toBeVisible();
-  await expect(page.getByText('Page Y: 100.0')).toBeVisible();
-  await expect(page.getByText('Offset X: 80.0')).toBeVisible();
-  await expect(page.getByText('Offset Y: 6.0')).toBeVisible();
+  await expect(page.getByText('Client X: 100')).toBeVisible();
+  await expect(page.getByText('Client Y: 100')).toBeVisible();
+  await expect(page.getByText('Page X: 100')).toBeVisible();
+  await expect(page.getByText('Page Y: 100')).toBeVisible();
+  await expect(page.getByText('Offset X: 80')).toBeVisible();
+  await expect(page.getByText('Offset Y: 6')).toBeVisible();
 });
 
 test('test right click event', async ({page}) => {
@@ -22,10 +22,10 @@ test('test right click event', async ({page}) => {
 
   await expect(page.getByText('Is Click: True')).toBeVisible();
   await expect(page.getByText('Is Right Click: True')).toBeVisible();
-  await expect(page.getByText('Client X: 100.0')).toBeVisible();
-  await expect(page.getByText('Client Y: 100.0')).toBeVisible();
-  await expect(page.getByText('Page X: 100.0')).toBeVisible();
-  await expect(page.getByText('Page Y: 100.0')).toBeVisible();
-  await expect(page.getByText('Offset X: 80.0')).toBeVisible();
-  await expect(page.getByText('Offset Y: 6.0')).toBeVisible();
+  await expect(page.getByText('Client X: 100')).toBeVisible();
+  await expect(page.getByText('Client Y: 100')).toBeVisible();
+  await expect(page.getByText('Page X: 100')).toBeVisible();
+  await expect(page.getByText('Page Y: 100')).toBeVisible();
+  await expect(page.getByText('Offset X: 80')).toBeVisible();
+  await expect(page.getByText('Offset Y: 6')).toBeVisible();
 });

--- a/mesop/components/button/button.proto
+++ b/mesop/components/button/button.proto
@@ -3,12 +3,13 @@ syntax = "proto2";
 
 package mesop.components.button;
 
+// Next ID: 8
 message ButtonType {
   optional string color = 1;
   optional bool disable_ripple = 2;
   optional bool disabled = 3;
   optional string on_click_handler_id = 4;
-
+  optional string on_right_click_handler_id = 7;
   // Type has two properties:
   // |type_index| is used for rendering
   // |type| is used for editor value

--- a/mesop/components/button/button.py
+++ b/mesop/components/button/button.py
@@ -28,7 +28,7 @@ def button(
 
   Args:
     label: Text label for button
-    on_click: [click](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/click_event) is a native browser event.
+    on_click: [click](https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event) is a native browser event.
     type: Type of button style to use
     color: Theme color palette of the button
     disable_ripple: Whether the ripple effect is disabled or not.
@@ -64,7 +64,7 @@ def content_button(
   Intended for advanced use cases.
 
   Args:
-    on_click: [click](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/click_event) is a native browser event.
+    on_click: [click](https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event) is a native browser event.
     type: Type of button style to use
     color: Theme color palette of the button
     disable_ripple: Whether the ripple effect is disabled or not.

--- a/mesop/components/button/button.ts
+++ b/mesop/components/button/button.ts
@@ -34,12 +34,18 @@ export class ButtonComponent {
     return this._config;
   }
 
-  onClick(event: Event): void {
+  onClick(event: MouseEvent): void {
     const userEvent = new UserEvent();
     userEvent.setHandlerId(this.config().getOnClickHandlerId()!);
     userEvent.setKey(this.key);
     const click = new ClickEvent();
     click.setIsTarget(event.target === event.currentTarget);
+    click.setClientX(event.clientX);
+    click.setClientY(event.clientY);
+    click.setPageX(event.pageX);
+    click.setPageY(event.pageY);
+    click.setOffsetX(event.offsetX);
+    click.setOffsetY(event.offsetY);
     userEvent.setClick(click);
     this.channel.dispatch(userEvent);
   }

--- a/mesop/components/button/button.ts
+++ b/mesop/components/button/button.ts
@@ -2,6 +2,7 @@ import {MatButtonModule} from '@angular/material/button';
 import {Component, Input} from '@angular/core';
 import {
   ClickEvent,
+  RightClickEvent,
   UserEvent,
   Key,
   Type,
@@ -39,6 +40,28 @@ export class ButtonComponent {
     userEvent.setHandlerId(this.config().getOnClickHandlerId()!);
     userEvent.setKey(this.key);
     const click = new ClickEvent();
+    click.setIsTarget(event.target === event.currentTarget);
+    click.setClientX(event.clientX);
+    click.setClientY(event.clientY);
+    click.setPageX(event.pageX);
+    click.setPageY(event.pageY);
+    click.setOffsetX(event.offsetX);
+    click.setOffsetY(event.offsetY);
+    userEvent.setClick(click);
+    this.channel.dispatch(userEvent);
+  }
+
+  onRightClick(event: MouseEvent): void {
+    if (!this.config().getOnRightClickHandlerId()) {
+      return;
+    }
+
+    event.preventDefault();
+
+    const userEvent = new UserEvent();
+    userEvent.setHandlerId(this.config().getOnRightClickHandlerId()!);
+    userEvent.setKey(this.key);
+    const click = new RightClickEvent();
     click.setIsTarget(event.target === event.currentTarget);
     click.setClientX(event.clientX);
     click.setClientY(event.clientY);

--- a/mesop/events/__init__.py
+++ b/mesop/events/__init__.py
@@ -11,5 +11,8 @@ from .events import (
   MesopEvent as MesopEvent,
 )
 from .events import (
+  RightClickEvent as RightClickEvent,
+)
+from .events import (
   WebEvent as WebEvent,
 )

--- a/mesop/events/events.py
+++ b/mesop/events/events.py
@@ -13,13 +13,13 @@ class ClickEvent(MesopEvent):
 
   Attributes:
       key (str): key of the component that emitted this event.
-      is_target (bool): Whether the clicked target is the component which attached the event handler.
-      client_x (float): X coordinate relative to the viewport
-      client_y (float): Y coordinate relative to the viewport
-      page_x (float): X coordinate relative to the entire document, including scrolled parts
-      page_y (float): Y coordinate relative to the entire document, including scrolled parts
-      offset_x (float): X coordinate relative to the element
-      offset_y (float): Y coordinate relative to the element
+      is_target: Whether the clicked target is the component which attached the event handler.
+      client_x: X coordinate relative to the viewport.
+      client_y: Y coordinate relative to the viewport.
+      page_x: X coordinate relative to the entire document, including scrolled parts.
+      page_y: Y coordinate relative to the entire document, including scrolled parts.
+      offset_x: X coordinate relative to the element.
+      offset_y: Y coordinate relative to the element.
   """
 
   is_target: bool

--- a/mesop/events/events.py
+++ b/mesop/events/events.py
@@ -14,9 +14,39 @@ class ClickEvent(MesopEvent):
   Attributes:
       key (str): key of the component that emitted this event.
       is_target (bool): Whether the clicked target is the component which attached the event handler.
+      client_x (float): X coordinate relative to the viewport
+      client_y (float): Y coordinate relative to the viewport
+      page_x (float): X coordinate relative to the entire document, including scrolled parts
+      page_y (float): Y coordinate relative to the entire document, including scrolled parts
+      offset_x (float): X coordinate relative to the element
+      offset_y (float): Y coordinate relative to the element
   """
 
   is_target: bool
+  client_x: float
+  client_y: float
+  page_x: float
+  page_y: float
+  offset_x: float
+  offset_y: float
+
+
+@dataclass(kw_only=True)
+class RightClickEvent(ClickEvent):
+  """Represents a user right click event.
+
+  Attributes:
+      key (str): key of the component that emitted this event.
+      is_target (bool): Whether the clicked target is the component which attached the event handler.
+      client_x (float): X coordinate relative to the viewport
+      client_y (float): Y coordinate relative to the viewport
+      page_x (float): X coordinate relative to the entire document, including scrolled parts
+      page_y (float): Y coordinate relative to the entire document, including scrolled parts
+      offset_x (float): X coordinate relative to the element
+      offset_y (float): Y coordinate relative to the element
+  """
+
+  pass
 
 
 @dataclass(kw_only=True)

--- a/mesop/protos/ui.proto
+++ b/mesop/protos/ui.proto
@@ -24,7 +24,7 @@ message QueryParam {
     repeated string values = 2;
 }
 
-// Next ID: 20
+// Next ID: 21
 message UserEvent {
     optional States states = 1;
 
@@ -48,6 +48,7 @@ message UserEvent {
         bytes bytes_value = 9;
         ChangePrefersColorScheme change_prefers_color_scheme = 14;
         ClickEvent click = 16;
+        RightClickEvent right_click = 20;
         TextareaShortcutEvent textarea_shortcut = 17;
         DateRangePickerEvent date_range_picker_event = 18;
     }
@@ -83,8 +84,31 @@ message ArgPathSegment {
 }
 
 // Click event parameters
+//
+// Next ID: 8
 message ClickEvent {
     optional bool is_target = 1;
+    optional bool is_right_click = 2;
+    optional float client_x = 3;
+    optional float client_y = 4;
+    optional float page_x = 5;
+    optional float page_y = 6;
+    optional float offset_x = 7;
+    optional float offset_y = 8;
+}
+
+// Right click event parameters
+//
+// Next ID: 8
+message RightClickEvent {
+    optional bool is_target = 1;
+    optional bool is_right_click = 2;
+    optional float client_x = 3;
+    optional float client_y = 4;
+    optional float page_x = 5;
+    optional float page_y = 6;
+    optional float offset_x = 7;
+    optional float offset_y = 8;
 }
 
 // Shortcut event for textareas.

--- a/mesop/static/context_menu.css
+++ b/mesop/static/context_menu.css
@@ -1,0 +1,3 @@
+.menu-item {
+  filter: brightness(0.8);
+}

--- a/mesop/web/src/component_renderer/component_renderer.ts
+++ b/mesop/web/src/component_renderer/component_renderer.ts
@@ -325,7 +325,7 @@ Make sure the web component name is spelled the same between Python and JavaScri
     return '';
   }
 
-  onClick(event: Event) {
+  onClick(event: MouseEvent) {
     if (!this._boxType) {
       return;
     }
@@ -334,6 +334,12 @@ Make sure the web component name is spelled the same between Python and JavaScri
     userEvent.setKey(this.component.getKey());
     const click = new ClickEvent();
     click.setIsTarget(event.target === event.currentTarget);
+    click.setClientX(event.clientX);
+    click.setClientY(event.clientY);
+    click.setPageX(event.pageX);
+    click.setPageY(event.pageY);
+    click.setOffsetX(event.offsetX);
+    click.setOffsetY(event.offsetY);
     userEvent.setClick(click);
     this.channel.dispatch(userEvent);
   }


### PR DESCRIPTION
- This change adds some new properties to the click event for getting x/y coordinates on click event
- Also adds a right click event that overrides contextmenu event (ended up making this a separate event so we know when to disable the contextmenu (though maybe could have used click event and added is_right_click)
- Also added simple example of a context menu in Mesop with a right click.

- Closes #1272 
- Closes #301