### PR TITLE
Add support for configuring Cross Origin Opener Policy

### DIFF
--- a/mesop/examples/testing/__init__.py
+++ b/mesop/examples/testing/__init__.py
@@ -11,6 +11,9 @@ from mesop.examples.testing import (
   conditional_event_handler as conditional_event_handler,
 )
 from mesop.examples.testing import (
+  coop as coop,
+)
+from mesop.examples.testing import (
   csp_escaping as csp_escaping,
 )
 from mesop.examples.testing import (

--- a/mesop/examples/testing/coop.py
+++ b/mesop/examples/testing/coop.py
@@ -1,0 +1,34 @@
+import mesop as me
+
+
+@me.page(
+  path="/testing/coop_same_origin",
+  title="COOP: Same Origin",
+  security_policy=me.SecurityPolicy(
+    cross_origin_opener_policy="same-origin",
+  ),
+)
+def page_same_origin():
+  me.text("COOP - Same Origin")
+
+
+@me.page(
+  path="/testing/coop_same_origin_allow_popups",
+  title="COOP: Same Origin Allow Popups",
+  security_policy=me.SecurityPolicy(
+    cross_origin_opener_policy="same-origin-allow-popups",
+  ),
+)
+def page_same_origin_allow_popups():
+  me.text("COOP - Same Origin Allow Popups")
+
+
+@me.page(
+  path="/testing/coop_noopener_allow_popups",
+  title="COOP: Noopener Allow Popups",
+  security_policy=me.SecurityPolicy(
+    cross_origin_opener_policy="noopener-allow-popups",
+  ),
+)
+def page_noopener_allow_popups():
+  me.text("COOP - Noopener Allow Popups")

--- a/mesop/security/security_policy.py
+++ b/mesop/security/security_policy.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass, field
+from typing import Literal
 
 from mesop.exceptions import MesopDeveloperException
 
@@ -9,6 +10,7 @@ class SecurityPolicy:
   A class to represent the security policy.
 
   Attributes:
+    cross_origin_opener_policy: See [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Cross-Origin-Opener-Policy).
     allowed_iframe_parents: A list of allowed iframe parents.
     allowed_connect_srcs: A list of sites you can connect to, see [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/connect-src).
     allowed_script_srcs: A list of sites you can load scripts from, see [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src).
@@ -20,6 +22,12 @@ class SecurityPolicy:
       it's an important web security feature!
   """
 
+  cross_origin_opener_policy: Literal[
+    "unsafe-none",
+    "same-origin-allow-popups",
+    "same-origin",
+    "noopener-allow-popups",
+  ] = "unsafe-none"
   allowed_iframe_parents: list[str] = field(default_factory=list)
   allowed_connect_srcs: list[str] = field(default_factory=list)
   allowed_script_srcs: list[str] = field(default_factory=list)

--- a/mesop/server/static_file_serving.py
+++ b/mesop/server/static_file_serving.py
@@ -264,6 +264,12 @@ def configure_static_file_serving(
     security_policy = None
     if page_config and page_config.security_policy:
       security_policy = page_config.security_policy
+
+    if security_policy and security_policy.cross_origin_opener_policy:
+      response.headers["Cross-Origin-Opener-Policy"] = (
+        security_policy.cross_origin_opener_policy
+      )
+
     if security_policy and security_policy.allowed_connect_srcs:
       csp["connect-src"] = "'self' " + " ".join(
         [

--- a/mesop/tests/e2e/web_security_test.ts
+++ b/mesop/tests/e2e/web_security_test.ts
@@ -32,6 +32,30 @@ testInProdOnly('csp trusted types', async ({page}) => {
   expect(cleanCsp(csp)).toMatchSnapshot('csp_trusted_types.txt');
 });
 
+testInProdOnly('coop: default', async ({page}) => {
+  const response = await page.goto('/');
+  const coop = response?.headers()['cross-origin-opener-policy']!;
+  expect(coop).toEqual('unsafe-none');
+});
+
+testInProdOnly('coop: same origin', async ({page}) => {
+  const response = await page.goto('/testing/coop_same_origin');
+  const coop = response?.headers()['cross-origin-opener-policy']!;
+  expect(coop).toEqual('same-origin');
+});
+
+testInProdOnly('coop: same origin allow popups', async ({page}) => {
+  const response = await page.goto('/testing/coop_same_origin_allow_popups');
+  const coop = response?.headers()['cross-origin-opener-policy']!;
+  expect(coop).toEqual('same-origin-allow-popups');
+});
+
+testInProdOnly('coop: noopener allow popups', async ({page}) => {
+  const response = await page.goto('/testing/coop_noopener_allow_popups');
+  const coop = response?.headers()['cross-origin-opener-policy']!;
+  expect(coop).toEqual('noopener-allow-popups');
+});
+
 function cleanCsp(csp: string): string {
   return (
     csp


### PR DESCRIPTION
- We should probably set the default to same-origin, but worried about it breaking some existing apps, so just left it as the default value