### PR TITLE
This is a temp fix for Web Socket reconnect behavior.

### DIFF
--- a/mesop/web/src/services/channel.ts
+++ b/mesop/web/src/services/channel.ts
@@ -7,6 +7,7 @@ import {
   UserEvent,
   Component as ComponentProto,
   UiResponse,
+  InitRequest,
   Command,
   ChangePrefersColorScheme,
   HotReloadEvent,
@@ -232,7 +233,20 @@ export class Channel {
             5000,
           );
           setTimeout(() => {
-            this.initWebSocket(initParams, request);
+            // Create a new initial request object when reconnecting the websocket.
+            //
+            // This is to ensure that we get the latest viewport / theme settings / query params
+            // on refresh for the user.
+            //
+            // This is only a temporary fix. Ideally, when the websocket reconnects, it should
+            // retain the existing state and continue from there.
+            const refreshRequest = new UiRequest();
+            const initRequest = new InitRequest();
+            initRequest.setViewportSize(getViewportSize());
+            initRequest.setThemeSettings(this.themeService.getThemeSettings());
+            initRequest.setQueryParamsList(getQueryParams());
+            refreshRequest.setInit(initRequest);
+            this.initWebSocket(initParams, refreshRequest);
           }, backoffDelay);
         }
       });


### PR DESCRIPTION
- Currently, the web socket will use the initial state when reconnecting.
- Ideally it should try to preserve the current UI state if possible.

This PR only provides a temporary fix to ensure query params are updated
to help a resolve user issue where they would like to reload state from
the db by using the update query params. This is because on Cloud Run
web socket connections last about 10 minutes or something before they
disconenct and reconenction is required.

However, there may be an additional issue with query params. See #1283
that may block this temp fix.

Ref #1276