### PR TITLE
Update old Gemini 1.5 model references.

### DIFF
--- a/ai/docbot/docs_index.py
+++ b/ai/docbot/docs_index.py
@@ -141,7 +141,7 @@ if me.runtime().is_hot_reload_in_progress:
 
 else:
   index, bm25_retriever = build_or_load_index()
-  llm = Gemini(model="models/gemini-1.5-flash-latest")
+  llm = Gemini(model="models/gemini-flash-latest")
   retriever = QueryFusionRetriever(
     [
       index.as_retriever(similarity_top_k=5),

--- a/ai/prompt_context/transform_txt.py
+++ b/ai/prompt_context/transform_txt.py
@@ -63,7 +63,7 @@ Prioritize accuracy and completeness while minimizing token usage. Preserve code
 
 genai.configure(api_key=os.getenv("GEMINI_API_KEY"))  # type: ignore
 
-model = genai.GenerativeModel("gemini-1.5-flash-latest")
+model = genai.GenerativeModel("gemini-flash-latest")
 
 
 def generate_refined_text(content: str):

--- a/demo/llm_playground.py
+++ b/demo/llm_playground.py
@@ -20,7 +20,7 @@ class State:
   prompt_tab: bool = True
   response_tab: bool = True
   # Model configs
-  selected_model: str = "gemini-1.5"
+  selected_model: str = "gemini-2.5"
   selected_region: str = "us-east4"
   temperature: float = 1.0
   temperature_for_input: float = 1.0
@@ -128,7 +128,7 @@ def page():
     with me.box(style=_STYLE_CONFIG_COLUMN):
       me.select(
         options=[
-          me.SelectOption(label="Gemini 1.5", value="gemini-1.5"),
+          me.SelectOption(label="Gemini 2.5", value="gemini-2.5"),
           me.SelectOption(label="Chat-GPT Turbo", value="gpt-3.5-turbo"),
         ],
         label="Model",

--- a/docs/codelab/4.md
+++ b/docs/codelab/4.md
@@ -29,7 +29,7 @@ def configure_gemini():
 def send_prompt_pro(prompt: str, history: list[ChatMessage]) -> Iterable[str]:
     configure_gemini()
     model = genai.GenerativeModel(
-        model_name="gemini-1.5-pro-latest",
+        model_name="gemini-2.5-pro",
         generation_config=generation_config,
     )
     chat_session = model.start_chat(
@@ -43,7 +43,7 @@ def send_prompt_pro(prompt: str, history: list[ChatMessage]) -> Iterable[str]:
 def send_prompt_flash(prompt: str, history: list[ChatMessage]) -> Iterable[str]:
     configure_gemini()
     model = genai.GenerativeModel(
-        model_name="gemini-1.5-flash-latest",
+        model_name="gemini-flash-latest",
         generation_config=generation_config,
     )
     chat_session = model.start_chat(


### PR DESCRIPTION
The 1.5 models are no longer usable, so update to 2.5 variants.

Closes #1307