### PR TITLE
Restrict state restore to declared dataclass fields

### DIFF
--- a/mesop/dataclass_utils/dataclass_utils.py
+++ b/mesop/dataclass_utils/dataclass_utils.py
@@ -133,6 +133,14 @@ def _recursive_update_dataclass_from_json_obj(instance: Any, json_dict: Any):
       raise MesopDeveloperException(
         f"Cannot use dunder property: {key} in stateclass"
       )
+    if (
+      not isinstance(instance, dict)
+      and hasattr(instance, key)
+      and key not in getattr(instance, "__dataclass_fields__", {})
+    ):
+      raise MesopDeveloperException(
+        f"Cannot set non-dataclass-field property: {key} in stateclass"
+      )
     if hasattr(instance, key):
       attr = getattr(instance, key)
       if isinstance(value, dict):

--- a/mesop/dataclass_utils/dataclass_utils_test.py
+++ b/mesop/dataclass_utils/dataclass_utils_test.py
@@ -621,7 +621,7 @@ def test_class_level_attribute_pollution_blocked():
   """
 
   class MutableRoleMap(dict):
-    __hash__ = object.__hash__  # (mimic a hashable-but-mutable gadget)
+    __hash__ = object.__hash__  # type: ignore (mimic a hashable-but-mutable gadget)
 
   class RoleService:
     # Class-level (not annotated, so not a dataclass field) shared mapping.

--- a/mesop/dataclass_utils/dataclass_utils_test.py
+++ b/mesop/dataclass_utils/dataclass_utils_test.py
@@ -621,7 +621,7 @@ def test_class_level_attribute_pollution_blocked():
   """
 
   class MutableRoleMap(dict):
-    __hash__ = object.__hash__  # noqa: A003 (mimic a hashable-but-mutable gadget)
+    __hash__ = object.__hash__  # (mimic a hashable-but-mutable gadget)
 
   class RoleService:
     # Class-level (not annotated, so not a dataclass field) shared mapping.

--- a/mesop/dataclass_utils/dataclass_utils_test.py
+++ b/mesop/dataclass_utils/dataclass_utils_test.py
@@ -612,5 +612,37 @@ def test_globals_pollution():
   assert __name__ == initial_name
 
 
+def test_class_level_attribute_pollution_blocked():
+  """Regression test for class-level mutable attribute pollution.
+
+  A non-dunder key that resolves to a class-level attribute (rather than a
+  declared dataclass field) must be rejected, since setting it would mutate
+  state shared across all sessions instead of the per-instance field.
+  """
+
+  class MutableRoleMap(dict):
+    __hash__ = object.__hash__  # noqa: A003 (mimic a hashable-but-mutable gadget)
+
+  class RoleService:
+    # Class-level (not annotated, so not a dataclass field) shared mapping.
+    role_map = MutableRoleMap({"assistant": "user"})
+
+  @dataclass
+  class ChatState:
+    service: RoleService = field(default_factory=RoleService)
+
+  state = ChatState()
+  with pytest.raises(MesopDeveloperException) as exc_info:
+    update_dataclass_from_json(
+      state, '{"service": {"role_map": {"assistant": "system"}}}'
+    )
+  assert (
+    "Cannot set non-dataclass-field property: role_map in stateclass"
+    in str(exc_info.value)
+  )
+  # Make sure the shared class-level mapping was not mutated.
+  assert RoleService.role_map == {"assistant": "user"}
+
+
 if __name__ == "__main__":
   raise SystemExit(pytest.main(["-vv", __file__]))


### PR DESCRIPTION
## Summary

- A security advisory reported that `update_dataclass_from_json` (via `/__ui__` `UserEvent` state blobs) blocks dunder keys and unhashable class-level defaults, but ordinary non-dunder keys can still reach hashable, mutable **class-level** attributes through normal `hasattr`/`getattr`/`setattr` fallback — letting a crafted state payload mutate an object shared across all sessions (e.g. a `dict` subclass with a custom `__hash__` used as a class attribute on a nested state object).
- I reproduced the chain against current `main` and confirmed it's valid: the mutation lands during `update_state()` in `mesop/runtime/context.py`, which runs before the handler-id lookup, so the developer error returned afterward doesn't roll back the damage.
- Fix: in `_recursive_update_dataclass_from_json_obj`, a non-dunder key resolved via `hasattr` is now also required to be a declared `__dataclass_fields__` entry on the target — unless the target is a plain `dict` (dict-typed state fields, e.g. `dict[str, bool]`, still restore arbitrary keys as before).

## Test plan

- [x] Added `test_class_level_attribute_pollution_blocked` reproducing the advisory's `RoleService`/`MutableRoleMap` PoC, asserting the update is rejected and the shared class-level mapping is left untouched.
- [x] Verified existing patterns still work by exercising the module directly (couldn't run full `bazel`/`pytest` suite in this sandbox — no bazel/protoc available to generate `mesop.protos.ui_pb2`): nested dataclasses, lists of dataclasses, dict/nested-dict-typed fields, unannotated nested state classes with declared fields, and the existing dunder-key protection.
- [ ] CI should run the full test suite on this PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MC1XyvNKytmVvBSgtPqJpv)_