### PR TITLE
Add site-wide banner noting Mesop is no longer maintained

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Mesop: Build delightful web apps quickly in Python 🚀
 
+> [!WARNING]
+> **Mesop is no longer maintained as of September 30, 2026.** No further updates, bug fixes, or support will be provided.
+
 [![PyPI](https://img.shields.io/pypi/v/mesop)](https://pypi.org/project/mesop/)
 [![PyPI downloads](https://img.shields.io/pypi/dm/mesop)](https://pypi.org/project/mesop/)
 [![Twitter follow](https://img.shields.io/twitter/follow/mesop_dev?style=social&label=follow)](https://twitter.com/mesop_dev)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Mesop: Build delightful web apps quickly in Python 🚀
 
+<!-- prettier-ignore -->
 > [!WARNING]
 > **Mesop is no longer maintained as of September 30, 2026.** No further updates, bug fixes, or support will be provided.
 

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -562,3 +562,14 @@ h3#mesop\.features\.theme\.ThemeVar {
     align-items: center;
   }
 }
+
+/* Archival notice banner (see docs/theme/main.html) */
+.md-banner {
+  background-color: var(--amber-600);
+  color: var(--white);
+}
+
+.md-banner a {
+  color: var(--white);
+  text-decoration: underline;
+}

--- a/docs/theme/main.html
+++ b/docs/theme/main.html
@@ -1,6 +1,3 @@
-{% extends "base.html" %}
-
-{% block announce %}
+{% extends "base.html" %} {% block announce %}
 <strong>⚠️ Mesop is no longer maintained as of September 30, 2026.</strong>
-No further updates, bug fixes, or support will be provided.
-{% endblock %}
+No further updates, bug fixes, or support will be provided. {% endblock %}

--- a/docs/theme/main.html
+++ b/docs/theme/main.html
@@ -1,0 +1,6 @@
+{% extends "base.html" %}
+
+{% block announce %}
+<strong>⚠️ Mesop is no longer maintained as of September 30, 2026.</strong>
+No further updates, bug fixes, or support will be provided.
+{% endblock %}


### PR DESCRIPTION
Overrides mkdocs-material's announce block to show a persistent
amber banner on every docs page stating Mesop is no longer
maintained as of September 30, 2026.